### PR TITLE
Simple fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ $ echo '++++ [> +++++ +++++ < - ] > .' | ocaml brainfuck.ml -fmt integer
 
 Leave out `-fmt` option to print out ASCII characters as a default.
 
-```brainfuck
+hello.bf:
 
-hello.txt
+```brainfuck
 
 > +++++++ [ > +++++ +++++ < - ] > ++ .
 > +++++ +++++ [ > +++++ +++++ < - ] > + .

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ sample.bf:
 
 ```brainfuck
 
-Below calculates  100
+Below calculates 50
 
 +++++ [ > +++++ +++++ < - ] > .
 
@@ -27,8 +27,9 @@ run as a command line tool:
 
 ```bash
 
-# Prints '100'.
+# Prints '50'.
 $ ocaml brainfuck.ml sample.bf -fmt integer
+# Prints '40'
 $ echo '++++ [> +++++ +++++ < - ] > .' | ocaml brainfuck.ml -fmt integer
 
 ```

--- a/brainfuck.mli
+++ b/brainfuck.mli
@@ -1,2 +1,2 @@
 (** interpret a Brainfuck string **)
-val interpret : string -> string
+val interpret : ?tape_size:int -> ?format:string -> string -> unit


### PR DESCRIPTION
I've thinking about learning OCaml and write myself a Brainfuck interpreter, so this has been helpful, thanks!

I just had a couple of issues running this project:

### Compilation

Even though I could compile the `.mli` file, it had different signatures than the implementation one, I've got this error:
```
otaviopace@Otavios-MacBook-Pro ~/ml-brainfuck (master)> ocamlopt -c brainfuck.ml
File "brainfuck.ml", line 1:
Error: The implementation brainfuck.ml
       does not match the interface brainfuck.cmi:
       Values do not match:
         val interpret : ?tape_size:int -> ?format:string -> string -> unit
       is not included in
         val interpret : string -> string
       File "brainfuck.mli", line 2, characters 0-32: Expected declaration
       File "brainfuck.ml", line 17, characters 4-13: Actual declaration
```
![Screen Shot 2021-05-22 at 10 36 14](https://user-images.githubusercontent.com/15306309/119228474-89fae680-bae9-11eb-9932-0d3c3c5137e5.png)

So I've fixed the interface file 😉 

### hello.txt example

This example had the name of the file inside it, and since it has an extension, the `.` could be interpreted as part of the program, so I made it similar to the other examples where the name is before the content.

### Wrong outputs

In `README.md` it was saying the output would be `100`, but it was `50` and `40`, like shown below:

```
otaviopace@Otavios-MacBook-Pro ~/ml-brainfuck (master)> ocaml brainfuck.ml sample.bf -fmt integer
50⏎                                                                                                                                                                                                                 otaviopace@Otavios-MacBook-Pro ~/ml-brainfuck (master)> echo '++++ [> +++++ +++++ < - ] > .' | ocaml brainfuck.ml -fmt integer
40
```
![Screen Shot 2021-05-22 at 10 39 38](https://user-images.githubusercontent.com/15306309/119228583-042b6b00-baea-11eb-8ee1-31ed471ec14d.png)

So I've fixed the outputs on `README.md`.

